### PR TITLE
Add Poetry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ The application is built with **Streamlit** and relies on the following librarie
 
 ## Setup
 
+Install the dependencies using [Poetry](https://python-poetry.org):
+
+```bash
+poetry install
+```
+
+If you prefer using `pip`, an exported `requirements.txt` is also provided:
+
 ```bash
 pip install -r requirements.txt
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "evaluate-your-english"
+version = "0.1.0"
+description = "Streamlit app for English pronunciation and grammar evaluation"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+streamlit = "*"
+faster-whisper = "*"
+phonemizer = "*"
+editdistance = "*"
+transformers = "*"
+torch = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with Poetry metadata and dependencies
- document `poetry install` in README

## Testing
- `poetry export -f requirements.txt --output requirements.txt --without-hashes` *(fails: The requested command export does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684a7107c59c832cb603d3e391341010