### PR TITLE
Remove unused imports

### DIFF
--- a/evaluate/pronunciation.py
+++ b/evaluate/pronunciation.py
@@ -1,4 +1,3 @@
-import subprocess
 from phonemizer import phonemize
 from faster_whisper import WhisperModel
 
@@ -25,7 +24,6 @@ def pronunciation_score(audio_path: str, reference_text: str, model_size="base")
     pred_tokens = pred_phonemes.split()
 
     # simple edit distance
-    import numpy as np
     import editdistance
 
     distance = editdistance.eval(ref_tokens, pred_tokens)


### PR DESCRIPTION
## Summary
- prune unused imports from pronunciation module

## Testing
- `python -m pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a71280030832c961e8db4aafe5b14