### PR TITLE
Implement caching for models and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This app provides two core features:
 1. **English Pronunciation Evaluation** using a Whisper ASR model and phoneme comparison.
 2. **English Grammar Correction** using a transformer model.
 
+Both the grammar and pronunciation models are cached so they only load once per
+process. This significantly speeds up repeated evaluations.
+
 The application is built with **Streamlit** and relies on the following libraries:
 
 - `faster-whisper` for speech to text

--- a/evaluate/grammar.py
+++ b/evaluate/grammar.py
@@ -1,9 +1,11 @@
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 import torch
+from functools import lru_cache
 
 MODEL_NAME = "prithivida/grammar_error_correcter_v1"
 
 
+@lru_cache(maxsize=1)
 def load_model():
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
     model = AutoModelForSeq2SeqLM.from_pretrained(MODEL_NAME)

--- a/evaluate/pronunciation.py
+++ b/evaluate/pronunciation.py
@@ -1,7 +1,9 @@
 from phonemizer import phonemize
 from faster_whisper import WhisperModel
+from functools import lru_cache
 
 
+@lru_cache(maxsize=None)
 def load_whisper_model(model_size="base"):
     """Load a Whisper ASR model."""
     return WhisperModel(model_size)

--- a/tests/test_pronunciation_and_grammar.py
+++ b/tests/test_pronunciation_and_grammar.py
@@ -49,3 +49,56 @@ def test_correct_grammar(monkeypatch):
     monkeypatch.setattr(grammar, 'load_model', lambda: (dummy_tokenizer, dummy_model))
     result = grammar.correct_grammar('text with error')
     assert result == 'corrected'
+
+
+def test_correct_grammar_cached(monkeypatch):
+    counter = {'tokenizer': 0, 'model': 0}
+
+    class DummyTokenizer:
+        def __call__(self, text, return_tensors='pt'):
+            return {}
+
+        def decode(self, ids, skip_special_tokens=True):
+            return 'ok'
+
+    class DummyModel:
+        def generate(self, **inputs):
+            return [[1]]
+
+    def fake_tokenizer_from_pretrained(name):
+        counter['tokenizer'] += 1
+        return DummyTokenizer()
+
+    def fake_model_from_pretrained(name):
+        counter['model'] += 1
+        return DummyModel()
+
+    monkeypatch.setattr(grammar, 'AutoTokenizer', types.SimpleNamespace(from_pretrained=fake_tokenizer_from_pretrained))
+    monkeypatch.setattr(grammar, 'AutoModelForSeq2SeqLM', types.SimpleNamespace(from_pretrained=fake_model_from_pretrained))
+    grammar.load_model.cache_clear()
+
+    assert grammar.correct_grammar('one') == 'ok'
+    assert grammar.correct_grammar('two') == 'ok'
+    assert counter['tokenizer'] == 1
+    assert counter['model'] == 1
+
+
+def test_pronunciation_score_cached(monkeypatch):
+    counter = {'model': 0}
+
+    class DummyWhisperModel:
+        def __init__(self, size):
+            counter['model'] += 1
+
+    def fake_transcribe(model, audio_path):
+        assert isinstance(model, DummyWhisperModel)
+        return 'hello world'
+
+    monkeypatch.setattr(pronunciation, 'WhisperModel', DummyWhisperModel)
+    monkeypatch.setattr(pronunciation, 'phonemize', lambda text, language='en-us': text)
+    monkeypatch.setattr(pronunciation, 'transcribe_audio', fake_transcribe)
+    pronunciation.load_whisper_model.cache_clear()
+
+    pronunciation.pronunciation_score('a.wav', 'hello world')
+    pronunciation.pronunciation_score('b.wav', 'hello world')
+    assert counter['model'] == 1


### PR DESCRIPTION
## Summary
- cache model loading in `evaluate/grammar.py`
- cache whisper model in `evaluate/pronunciation.py`
- document caching behaviour in README
- test that repeated calls reuse cached models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7f4e35d8832cbf8820549c5676ae