### PR TITLE
Include streamlit-audiorecorder in Poetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 streamlit = "*"
+streamlit-audiorecorder = "*"
 faster-whisper = "*"
 phonemizer = "*"
 editdistance = "*"


### PR DESCRIPTION
## Summary
- add `streamlit-audiorecorder` to Poetry dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a81798fd0832c9d984a24e082a02b