### PR TITLE
Fix import for audiorecorder module

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,10 @@ import streamlit as st
 import tempfile
 from evaluate.pronunciation import pronunciation_score
 from evaluate.grammar import correct_grammar
-from streamlit_audiorecorder import audiorecorder
+# The audiorecorder package installs with the name ``audiorecorder``
+# even though the PyPI package is ``streamlit-audiorecorder``. Import
+# the function from the correct module to avoid ModuleNotFoundError.
+from audiorecorder import audiorecorder
 
 
 def main():


### PR DESCRIPTION
## Summary
- fix import path for the streamlit-audiorecorder package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9913bd54832cb5bfca18819be850