### PR TITLE
Add text level evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Evaluate Your English
 
-This app provides two core features:
+This app provides three core features:
 
 1. **English Pronunciation Evaluation** using a Whisper ASR model and phoneme comparison.
 2. **English Grammar Correction** using a transformer model.
+3. **English Text Level Assessment** based on Flesch readability metrics. This feature works on any text input, independent of the audio tools.
 
 Both the grammar and pronunciation models are cached so they only load once per
 process. This significantly speeds up repeated evaluations.
@@ -34,3 +35,8 @@ pip install -r requirements.txt
 ```bash
 streamlit run app.py
 ```
+
+## Text Level Assessment
+
+Use the dedicated text box in the app to evaluate the readability of any text.
+The results display Flesch Reading Ease and Flesch–Kincaid Grade Level.

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import tempfile
 from evaluate.pronunciation import pronunciation_score
 from evaluate.grammar import correct_grammar
+from evaluate.readability import evaluate_text_level
 from streamlit_audiorecorder import audiorecorder
 
 
@@ -44,6 +45,18 @@ def main():
         if transcription:
             st.write("Grammar Correction:")
             st.write(transcription)
+
+
+    st.header("Text Level Assessment")
+    input_text = st.text_area("Enter text to evaluate")
+    if st.button("Evaluate Text Level") and input_text:
+        readability = evaluate_text_level(input_text)
+        st.write(
+            f"Flesch Reading Ease: {readability['flesch_reading_ease']:.2f}"
+        )
+        st.write(
+            f"Flesch-Kincaid Grade: {readability['flesch_kincaid_grade']:.2f}"
+        )
 
 
 if __name__ == "__main__":

--- a/evaluate/readability.py
+++ b/evaluate/readability.py
@@ -1,0 +1,43 @@
+import re
+
+VOWELS = "aeiouy"
+
+
+def count_syllables(word: str) -> int:
+    """Rudimentary syllable count used for readability metrics."""
+    word = re.sub(r"[^a-z]", "", word.lower())
+    if not word:
+        return 0
+    syllables = 0
+    prev_vowel = False
+    for ch in word:
+        is_vowel = ch in VOWELS
+        if is_vowel and not prev_vowel:
+            syllables += 1
+        prev_vowel = is_vowel
+    if word.endswith("e") and syllables > 1:
+        syllables -= 1
+    return syllables or 1
+
+
+def evaluate_text_level(text: str) -> dict:
+    """Return Flesch Reading Ease and Flesch–Kincaid Grade Level for the text."""
+    sentences = [s.strip() for s in re.split(r"[.!?]+", text) if s.strip()]
+    words = re.findall(r"\b\w+\b", text.lower())
+    if not sentences or not words:
+        return {"flesch_reading_ease": 0.0, "flesch_kincaid_grade": 0.0}
+
+    total_sentences = len(sentences)
+    total_words = len(words)
+    total_syllables = sum(count_syllables(w) for w in words)
+
+    words_per_sentence = total_words / total_sentences
+    syllables_per_word = total_syllables / total_words
+
+    reading_ease = 206.835 - 1.015 * words_per_sentence - 84.6 * syllables_per_word
+    grade_level = 0.39 * words_per_sentence + 11.8 * syllables_per_word - 15.59
+
+    return {
+        "flesch_reading_ease": reading_ease,
+        "flesch_kincaid_grade": grade_level,
+    }

--- a/tests/test_readability.py
+++ b/tests/test_readability.py
@@ -1,0 +1,13 @@
+from evaluate.readability import evaluate_text_level
+
+
+def test_evaluate_text_level_simple():
+    result = evaluate_text_level("This is a simple sentence.")
+    assert isinstance(result, dict)
+    assert result["flesch_reading_ease"] > 90
+    assert 0 <= result["flesch_kincaid_grade"] < 1
+
+
+def test_evaluate_text_level_empty():
+    result = evaluate_text_level("")
+    assert result == {"flesch_reading_ease": 0.0, "flesch_kincaid_grade": 0.0}


### PR DESCRIPTION
## Summary
- support Flesch readability metrics for text evaluation
- display readability results in the Streamlit UI
- document the new feature
- test evaluate_text_level
- allow evaluating text readability separately from pronunciation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a99817428832c93a725ce074311df