### PR TITLE
Patch streamlit watcher and document workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ pip install -r requirements.txt
 ```bash
 streamlit run app.py
 ```
+
+If you encounter errors related to `torch.classes` when launching
+the app, note that `app.py` patches Streamlit's file watcher to skip
+this module. This workaround avoids a startup crash caused by
+`streamlit.watcher.local_sources_watcher` failing on
+`torch.classes`.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
-If you encounter errors related to `torch.classes` when launching
-the app, note that `app.py` patches Streamlit's file watcher to skip
-this module. This workaround avoids a startup crash caused by
+If you encounter errors related to `torch.classes` when launching the
+app, note that `app.py` patches Streamlit's file watcher to skip this
+module. This workaround avoids a startup crash caused by
 `streamlit.watcher.local_sources_watcher` failing on
 `torch.classes`.

--- a/app.py
+++ b/app.py
@@ -7,6 +7,22 @@ from evaluate.grammar import correct_grammar
 # the function from the correct module to avoid ModuleNotFoundError.
 from audiorecorder import audiorecorder
 
+import streamlit.watcher.local_sources_watcher as lsw
+
+_orig_extract_paths = lsw.extract_paths
+
+
+def _safe_extract_paths(module):
+    if getattr(module, "__name__", "") == "torch.classes":
+        return []
+    try:
+        return _orig_extract_paths(module)
+    except RuntimeError:
+        return []
+
+
+lsw.extract_paths = _safe_extract_paths
+
 
 def main():
     st.title("Evaluate Your English")


### PR DESCRIPTION
## Summary
- patch Streamlit's `extract_paths` to avoid errors with `torch.classes`
- document the workaround in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9ab01ae8832caba39505ce60f936