### PR TITLE
Handle optional Streamlit watcher patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ streamlit run app.py
 ```
 
 If you encounter errors related to `torch.classes` when launching the
-app, note that `app.py` patches Streamlit's file watcher to skip this
-module. This workaround avoids a startup crash caused by
+app, `app.py` attempts to patch Streamlit's file watcher to skip this
+module. The patch is optional and is automatically skipped when the
+watcher implementation doesn't expose the required hook. This
+workaround avoids a startup crash caused by
 `streamlit.watcher.local_sources_watcher` failing on
 `torch.classes`.
 ## Text Level Assessment

--- a/app.py
+++ b/app.py
@@ -5,21 +5,23 @@ from evaluate.grammar import correct_grammar
 from evaluate.readability import evaluate_text_level
 from audiorecorder import audiorecorder
 
-import streamlit.watcher.local_sources_watcher as lsw
+try:
+    import streamlit.watcher.local_sources_watcher as lsw
 
-_orig_extract_paths = lsw.extract_paths
+    if hasattr(lsw, "extract_paths"):
+        _orig_extract_paths = lsw.extract_paths
 
+        def _safe_extract_paths(module):
+            if getattr(module, "__name__", "") == "torch.classes":
+                return []
+            try:
+                return _orig_extract_paths(module)
+            except RuntimeError:
+                return []
 
-def _safe_extract_paths(module):
-    if getattr(module, "__name__", "") == "torch.classes":
-        return []
-    try:
-        return _orig_extract_paths(module)
-    except RuntimeError:
-        return []
-
-
-lsw.extract_paths = _safe_extract_paths
+        lsw.extract_paths = _safe_extract_paths
+except (ImportError, AttributeError):
+    pass
 
 
 def main():


### PR DESCRIPTION
## Summary
- make the Streamlit file watcher patch optional in `app.py`
- document that the patch is skipped if unsupported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e5166e0832c80cf1513d58077d3